### PR TITLE
Fix mysql client package

### DIFF
--- a/docker/loopback/Dockerfile
+++ b/docker/loopback/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir /app
 
 # Update Linux Packages
 RUN apt-get update && apt-get upgrade -y
-RUN apt-get install mysql-client -y
+RUN apt-get install default-mysql-client -y
 
 # Run update and Strongloop install
 RUN npm install -g npm


### PR DESCRIPTION
I tried to build my docker image but got the following error: E: Package 'mysql-client' has no installation candidate
Searched and learned that there is this substitute: default-mysql-client